### PR TITLE
Fix official golang repos urls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: go
-go: 
+go:
  - 1.1
  - release
  - tip
 
 install:
   - go get -u github.com/franela/goblin
-  - go get -u code.google.com/p/go.crypto/pbkdf2
+  - go get -u golang.org/x/crypto/pbkdf2
   - go get -u github.com/fiam/gounidecode/unidecode

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The inflector package relies on:
  [unidecode](http://godoc.org/github.com/fiam/gounidecode/unidecode) to handle the transliteration.
 
 The crypto package relies on:
-  [pbkdf2](http://code.google.com/p/go.crypto/pbkdf2) to handle the
+  [pbkdf2](http://golang.org/x/crypto/pbkdf2) to handle the
 generation of derived keys.
 
 The test suite uses

--- a/crypto/key_generator.go
+++ b/crypto/key_generator.go
@@ -1,7 +1,7 @@
 package crypto
 
 import (
-	"code.google.com/p/go.crypto/pbkdf2"
+	"golang.org/x/crypto/pbkdf2"
 	"crypto/sha1"
 	"fmt"
 )


### PR DESCRIPTION
The official golang repos URL has changed a while ago due the fact that google code is being shutdown.

This simply updates the URLs for packages.