### PR TITLE
Rails 5.2+ aes-gcm cookie support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,28 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/crypto/aes_gcm.go
+++ b/crypto/aes_gcm.go
@@ -1,0 +1,109 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+)
+
+func (crypt *MessageEncryptor) aesGCMEncrypt(value interface{}) (string, error) {
+	// TODO: check the crypt is properly initiated
+	k := crypt.Key
+	// The longest accepted key is 32 byte long,
+	// instead of rejecting a long key, we truncate it.
+	// This is how openssl in Ruby works.
+	if len(k) > 32 {
+		k = crypt.Key[:32]
+	}
+	block, err := aes.NewCipher(k)
+	if err != nil {
+		return "", err
+	}
+
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	// Set a default serializer if not already set
+	if crypt.Serializer == nil {
+		crypt.Serializer = JsonMsgSerializer{}
+	}
+	splaintext, err := crypt.Serializer.Serialize(value)
+	if err != nil {
+		return "", err
+	}
+	plaintext := []byte(splaintext)
+
+	iv := make([]byte, aesgcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return "", err
+	}
+
+	ciphertext := aesgcm.Seal(nil, iv, plaintext, nil)
+
+	// Rails stores the GCM auth tag separately from the encrypted data,
+	// unlike the cipher package, so a little munging is required.
+	// Luckily aesgcm.Overhead() is the tag size (which is 16).
+	tagStart := len(ciphertext) - aesgcm.Overhead()
+	tag := ciphertext[tagStart:]
+	enc := ciphertext[:tagStart]
+
+	vectors := [][]byte{enc, iv, tag}
+	for i, vec := range vectors {
+		dst := make([]byte, base64.StdEncoding.EncodedLen(len(vec)))
+		base64.StdEncoding.Encode(dst, vec)
+		vectors[i] = dst
+	}
+
+	output := string(bytes.Join(vectors, []byte("--")))
+	return output, nil
+}
+
+func (crypt *MessageEncryptor) aesGCMDecrypt(encryptedMsg string, target interface{}) error {
+	k := crypt.Key
+	// The longest accepted key is 32 byte long,
+	// instead of rejecting a long key, we truncate it.
+	// This is how openssl in Ruby works.
+	if len(k) > 32 {
+		k = crypt.Key[:32]
+	}
+
+	block, err := aes.NewCipher(k)
+	if err != nil {
+		return err
+	}
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return err
+	}
+
+	vectors := bytes.SplitN([]byte(encryptedMsg), []byte("--"), 3)
+	if len(vectors) != 3 {
+		return fmt.Errorf("missing vectors, want 3, got %d", len(vectors))
+	}
+	for i, vec := range vectors {
+		dst := make([]byte, base64.StdEncoding.DecodedLen(len(vec)))
+		n, err := base64.StdEncoding.Decode(dst, vec)
+		if err != nil {
+			return fmt.Errorf("bad base64 encoding")
+		}
+		vectors[i] = dst[:n]
+	}
+
+	enc := vectors[0]
+	// Rails splits the auth tag into a separate vector, which is unnecessary really, but fine.
+	enc = append(enc, vectors[2]...)
+	nonce := vectors[1]
+
+	plain, err := aesgcm.Open(nil, nonce, enc, nil)
+	if err != nil {
+		return err
+	}
+
+	return crypt.Serializer.Unserialize(string(plain), target)
+}

--- a/crypto/doc.go
+++ b/crypto/doc.go
@@ -1,15 +1,17 @@
 // Copyright (c) 2013, Matt Aimonetti
+// Copyright (c) 2021, James Tucker
 // Use of this source code is governed by a MIT style
-// license that can be found at http://mattaimonetti.mit-license.org
+// license that can be found at https://opensource.org/licenses/MIT
 
 /*
 
-This crypto package ports some of Ruby on Rails' crypto (version 4+)
-logic so encrypted/signed messages can be shared between a Ruby app and
-a Go app. That said, this library is useful to anyone wanting to
-encrypt/sign data.
+Package crypto ports some of Ruby on Rails' crypto:
+  * version 4+: encrypted & signed messages (aes-cbc)
+  * version 5.2+: encrypted & authenticated messages (aes-256-gcm)
+Messages can be shared between a Ruby app and a Go app. That said, this
+library is useful to anyone wanting to encrypt/sign/authenticate data.
 
-The initial focus of this package was to be able to easily  share a Rails web session with a Go
+The initial focus of this package was to be able to easily share a Rails web session with a Go
 app. Rails uses three classes provided by ActiveSupport (a library used
 and maintained by the Rails team)
   * MessageEncryptor
@@ -38,13 +40,15 @@ the GenerateRandomKey function.
 
 Session serializer
 
-As I'm writing this documentation, Rails doesn't let you change the
-default session serializer (Marhsal). To be able to share the session
-it needs to be serialized in a cross language format.
+Since Rails 5.2, the default session serializer can be set to use JSON by
+setting:
+  Rails.application.config.action_dispatch.cookies_serializer = :json.
+
+In older Rails versions, it is necessary to make changes in order to move
+away from the default session serializer (Marhsal). To be able to share the
+session it needs to be serialized in a cross language format.
 I wrote a patch to change Rails' default serializer to JSON:
 https://gist.github.com/mattetti/7624413
-Hopefully, an API will soon be available and JSON will become the default
-serializer.
 This package can use different serializers and you can also add your
 own. This is useful if for instance you only have Go apps and choose to
 use gob encoding or another encoding solution. Three serializers are
@@ -58,9 +62,10 @@ It's important to understand how Rails handles the crypto around the
 session.
 Here is a quick and high level of what Rails does (Ruby code):
 
-   # Secret set in the app.
+    # Secret set in the app.
     secret_key_base = "f7b5763636f4c1f3ff4bd444eacccca295d87b990cc104124017ad70550edcfd22b8e89465338254e0b608592a9aac29025440bfd9ce53579835ba06a86f85f9"
 
+    # Rails 4+ / aes-cbc:
     key_generator = ActiveSupport::CachingKeyGenerator.new(ActiveSupport::KeyGenerator.new(secret_key_base, iterations: 1000))
     secret = key_generator.generate_key("encrypted cookie")
     sign_secret = key_generator.generate_key("signed encrypted cookie")
@@ -70,6 +75,16 @@ Here is a quick and high level of what Rails does (Ruby code):
     encrypted_message = encryptor.encrypt_and_sign({msg: "hello world"})
     # The encrypted and signed message is stored in the session cookie
     # To decrypt and verify it:
+    # encryptor.decrypt_and_verify(encrypted_message) # => {:msg => "hello world"}
+
+    # Rails 5.2+ / aes-256-gcm:
+    key_generator = ActiveSupport::CachingKeyGenerator.new(ActiveSupport::KeyGenerator.new(secret_key_base, iterations: 1000))
+    secret = key_generator.generate_key("authenticated encrypted cookie", 32)
+    encryptor = ActiveSupport::MessageEncryptor.new(secret, cipher: 'aes-256-gcm', serializer: JSON)
+    # encrypt and authenticate the content of the session:
+    encrypted_message = encryptor.encrypt_and_sign({msg: "hello world"})
+    # The encrypted and authenticated message is stored in the session cookie
+    # To authenticate and decrypt it:
     # encryptor.decrypt_and_verify(encrypted_message) # => {:msg => "hello world"}
 
 The equivalent in Go is available in the documentation examples: http://godoc.org/github.com/mattetti/goRailsYourself/crypto#pkg-examples
@@ -85,7 +100,9 @@ generating the keys in Go, we need to match the iteration number to get
 the same keys. Note also that if the salt is changed in the Rails app,
 you need to update it in your Go code.
 
-There are two derived keys: one for encryption and one for signing.
+With aes-cbc mode, there are two derived keys: one for encryption and one for
+signing. With aes-256-gcm mode, there is only one key that is used for both
+authentication and encryption.
 These keys are derived from the same secret but are different to
 increase security. The keys are also of two different length.
 The message signature is done by default using HMAC/sha1 requiring
@@ -96,7 +113,7 @@ AES CBC keys so you can use two 64 byte keys.
 This is exactly what Rails does, it generates two keys of same length (64 bytes) and
 lets the OpenSSL wrapper truncate the key. I, however recommend you
 generate keys of different length to avoid any confusion.
-Here is an example:
+Here is an example for aes-cbc (Rails 4+):
 
   railsSecret := "f7b5763636f4c1f3ff4bd444eacccca295d87b990cc104124017ad70550edcfd22b8e89465338254e0b608592a9aac29025440bfd9ce53579835ba06a86f85f9"
   encryptedCookieSalt := []byte("encrypted cookie")
@@ -107,6 +124,14 @@ Here is an example:
   signSecret := kg.CacheGenerate(encryptedSignedCookieSalt, 64)
   e := MessageEncryptor{Key: secret, SignKey: signSecret}
 
+Here is an example for aes-256-gcm (Rails 5.2+):
+
+  railsSecret := "f7b5763636f4c1f3ff4bd444eacccca295d87b990cc104124017ad70550edcfd22b8e89465338254e0b608592a9aac29025440bfd9ce53579835ba06a86f85f9"
+  authenticatedCookieSalt := []byte("authenticated encrypted cookie")
+
+  kg := KeyGenerator{Secret: railsSecret}
+  secret := kg.CacheGenerate(authenticated, 32)
+  e := MessageEncryptor{Key: secret, Cipher: "aes-256-gcm"}
 
 Without Ruby
 
@@ -115,6 +140,10 @@ be used to communicate with apps that aren't in Ruby. As a matter of
 fact, you might want to use this library to encrypt/sign your web
 sessions/cookies even if you just have one Go app. The Rails implementation
 has been tested and vested by many people and is safe to use.
+
+It is recommended that new applications use the "aes-256-gcm" mode rather
+than the "aes-cbc" mode, as the prior is a less error prone scheme and does
+not rely on now out of favor cryptographic primitives.
 
 */
 package crypto

--- a/crypto/message_encryptor.go
+++ b/crypto/message_encryptor.go
@@ -15,11 +15,12 @@ import (
 // This can be used in situations similar to the MessageVerifier, but
 // where you don't want users to be able to determine the value of the payload.
 //
-// Different kind of ciphers will be supported, currently only Rails' default aes-cbc
-// is supported.
-// Note that as I'm writing this library, Rails default serializer is Ruby's Marshal
-// which is not safe and cross language. You need to switch the serializer to JSON or another
-// safer/cross language format to share encrypted messages between Ruby and Go.
+// Different kind of ciphers are supported:
+//  - aes-cbc - Rails' default until 5.2, requires a verifier
+//  - aes-256-gcm - Rails 5.2+ default, ignores verifier.
+//
+// Note: The old Rails default serializer, Marshal is neither safe or
+// portable across langauges, use the JSON serializer.
 type MessageEncryptor struct {
 	Key []byte
 	// optional property used to automatically set the
@@ -30,18 +31,33 @@ type MessageEncryptor struct {
 	Serializer MsgSerializer
 }
 
-// Encrypt and sign a message (string, struct, anything that can be safely serialized/serialized).
-// Note that even if you can just Encrypt()
-// in most cases you shouldn't use it directly and instead use this method.
-// The reason is that we need to sign the message in order to avoid
-// padding attacks.
+func (crypt *MessageEncryptor) withVerifier() bool {
+	switch crypt.Cipher {
+	case "aes-256-gcm":
+		return false
+	}
+	return true
+}
+
+// EncryptAndSign performs encryption with authentication, or encryption
+// followed by signing, depending on the selected cipher mode. message can be
+// any serializable type (string, struct, map, etc).
+// Note that even if you can just Encrypt() in most cases you shouldn't use it
+// directly and instead use this method.
+// For aes-cbc mode, encryption alone is neither signed or authenticated, and is
+// subject to padding oracle attacks.
 // Reference: http://www.limited-entropy.com/padding-oracle-attacks.
-// The output string can be converted back using DecryptAndVerify()
-// and is encoded using base64.
+// The output string can be converted back using DecryptAndVerify() and is
+// encoded using base64.
 func (crypt *MessageEncryptor) EncryptAndSign(value interface{}) (string, error) {
 	if crypt == nil {
 		return "", errors.New("can't call EncryptAndSign on a nil *MessageEncryptor")
 	}
+
+	if !crypt.withVerifier() {
+		return crypt.Encrypt(value)
+	}
+
 	// Set a default verifier if a signature key was given instead of setting the verifier directly.
 	if crypt.Verifier == nil && crypt.SignKey != nil {
 		crypt.Verifier = &MessageVerifier{
@@ -64,10 +80,17 @@ func (crypt *MessageEncryptor) EncryptAndSign(value interface{}) (string, error)
 	return crypt.Verifier.Generate(encryptedMsg)
 }
 
-// Decrypt and verify a message. Messages need to be signed on top of being encrypted in order to
+// DecryptAndVerify decrypts and either authenticates or verifies the signature
+// of a message, depending on the selected cipher mode. Messages need to be
+// either signed or authenticated (GCM) on top of being encrypted in order to
 // avoid padding attacks. Reference: http://www.limited-entropy.com/padding-oracle-attacks.
 // The serializer will populate the pointer you are passing as second argument.
 func (crypt *MessageEncryptor) DecryptAndVerify(msg string, target interface{}) error {
+
+	if !crypt.withVerifier() {
+		return crypt.Decrypt(msg, target)
+	}
+
 	// Set a default verifier if a signature key was given instead of setting the verifier directly.
 	if crypt.Verifier == nil && crypt.SignKey != nil {
 		crypt.Verifier = &MessageVerifier{
@@ -85,13 +108,15 @@ func (crypt *MessageEncryptor) DecryptAndVerify(msg string, target interface{}) 
 	return crypt.Decrypt(base64Msg, target)
 }
 
-// Encrypt() encrypts a message using the set cipher and the secret.
+// Encrypt encrypts a message using the set cipher and the secret.
 // The returned value is a base 64 encoded string of the encrypted data + IV joined by "--".
 // An encrypted message isn't safe unless it's signed!
 func (crypt *MessageEncryptor) Encrypt(value interface{}) (string, error) {
 	switch crypt.Cipher {
 	case "aes-cbc":
 		return crypt.aesCbcEncrypt(value)
+	case "aes-256-gcm":
+		return crypt.aesGCMEncrypt(value)
 	case "":
 		// using a default if not set
 		return crypt.aesCbcEncrypt(value)
@@ -99,7 +124,7 @@ func (crypt *MessageEncryptor) Encrypt(value interface{}) (string, error) {
 	return "", errors.New("cipher not set or not supported")
 }
 
-// decrypt() decrypts a message using the set cipher and the secret.
+// Decrypt decrypts a message using the set cipher and the secret.
 // The passed value is expected to be a base 64 encoded string of the encrypted data + IV joined by "--"
 func (crypt *MessageEncryptor) Decrypt(value string, target interface{}) error {
 	if crypt.Serializer == nil {
@@ -108,6 +133,8 @@ func (crypt *MessageEncryptor) Decrypt(value string, target interface{}) error {
 	switch crypt.Cipher {
 	case "aes-cbc":
 		return crypt.aesCbcDecrypt(value, target)
+	case "aes-256-gcm":
+		return crypt.aesGCMDecrypt(value, target)
 	case "":
 		// using a default if not set
 		return crypt.aesCbcDecrypt(value, target)

--- a/crypto/message_encryptor_test.go
+++ b/crypto/message_encryptor_test.go
@@ -2,10 +2,12 @@ package crypto
 
 import (
 	"crypto/sha1"
+	"encoding/json"
 	"fmt"
-	. "github.com/franela/goblin"
 	"strings"
 	"testing"
+
+	. "github.com/franela/goblin"
 )
 
 func TestMessageEncryptorDefaultSettings(t *testing.T) {
@@ -38,6 +40,76 @@ func TestMessageEncryptorDefaultSettings(t *testing.T) {
 
 func TestMessageEncryptor(t *testing.T) {
 	g := Goblin(t)
+
+	g.Describe("MessageEncryptor properly setup using aes-256-gcm", func() {
+		newCrypt := func() MessageEncryptor {
+			return MessageEncryptor{Key: GenerateRandomKey(32),
+				Cipher:     "aes-256-gcm",
+				Verifier:   nil,
+				Serializer: JsonMsgSerializer{},
+			}
+		}
+
+		g.It("can encrypt/decrypt an unsigned string", func() {
+			e := newCrypt()
+			msg, err := e.Encrypt("my secret data")
+			g.Assert(err).Eql(nil)
+			splitMsg := strings.Split(msg, "--")
+			g.Assert(len(splitMsg)).Eql(3)
+			var newMsg string
+			err = e.Decrypt(msg, &newMsg)
+			g.Assert(err).Eql(nil)
+			g.Assert(newMsg).Eql("my secret data")
+		})
+
+		g.It("can encrypt/decrypt an unsigned struct", func() {
+			type Person struct {
+				Id        int    `json:"id"`
+				FirstName string `json:"firstName"`
+				LastName  string `json:"lastName"`
+				Age       int    `json:"age"`
+			}
+			data := Person{Id: 12, FirstName: "John", LastName: "Doe", Age: 42}
+			e := newCrypt()
+			msg, err := e.Encrypt(data)
+			g.Assert(err).Eql(nil)
+			splitMsg := strings.Split(msg, "--")
+			g.Assert(len(splitMsg)).Eql(3)
+			var decryptedMsg Person
+			err = e.Decrypt(msg, &decryptedMsg)
+			g.Assert(err).Eql(nil)
+			g.Assert(decryptedMsg).Eql(data)
+		})
+
+		g.It("can round trip signed and encoded string", func() {
+			testData := "this is a test"
+			var e MessageEncryptor
+			for i := 0; i < 100; i++ {
+				e = newCrypt()
+				msg, err := e.EncryptAndSign(testData)
+				g.Assert(err).Eql(nil)
+				var output string
+				err = e.DecryptAndVerify(msg, &output)
+				g.Assert(err).Eql(nil)
+				if output != testData {
+					println(i, err.Error(), "FAILED", output, msg)
+					fmt.Printf("%#v\n", e)
+				}
+				g.Assert(output).Eql(testData)
+			}
+		})
+
+		g.It("can round trip signed and encoded struct", func() {
+			e := newCrypt()
+			testData := testStruct{Foo: "this is foo", Bar: 42}
+			msg, err := e.EncryptAndSign(testData)
+			g.Assert(err).Eql(nil)
+			var output testStruct
+			err = e.DecryptAndVerify(msg, &output)
+			g.Assert(err).Eql(nil)
+			g.Assert(output).Eql(testData)
+		})
+	})
 
 	g.Describe("MessageEncryptor properly setup using aes cbc", func() {
 		newCrypt := func() MessageEncryptor {
@@ -133,6 +205,27 @@ func TestDecryptingRailsSession(t *testing.T) {
 		g.It("can be decrypted", func() {
 			var session map[string]interface{}
 			err := e.DecryptAndVerify(cookieContent, &session)
+			j, _ := json.Marshal(session)
+			fmt.Printf("%s\n", j)
+			g.Assert(err).Eql(nil)
+			g.Assert(session["session_id"]).Eql("b2d63c07ea7a9d58e415e3672e3f31a2")
+		})
+	})
+
+	g.Describe("A Rails JSON session with aes-256-gcm", func() {
+		cookieContent := "Co+XxC9PK1ptoHftqua6C3PNrlvk4EA09IpKho+wk5qbMi4jrl6SS2g6xexK68b8kjKWqXzCcT/ZjkbAO/0Sxm01JIK0zY/qGa56ogFaVViZKgaCGlSQYDWrVDm3mCSTlTzHDl3nrIjMffwNEn2x5IPHaQQoR0skkv3A17zejE4d18pRqRYaCuZLg2H04HWYv0Y/s88Kurmevw8w/8xUwLIV8P3SpszfMHEU--Cs17rTBCsResqqC5--ym0c0ZE+ts7wExyw/t35QA=="
+		railsSecret := "f7b5763636f4c1f3ff4bd444eacccca295d87b990cc104124017ad70550edcfd22b8e89465338254e0b608592a9aac29025440bfd9ce53579835ba06a86f85f9"
+		encryptedCookieSalt := []byte("authenticated encrypted cookie")
+
+		kg := KeyGenerator{Secret: railsSecret}
+		secret := kg.CacheGenerate(encryptedCookieSalt, 32)
+
+		fmt.Printf("%x\n", secret)
+		e := MessageEncryptor{Key: secret, Cipher: "aes-256-gcm"}
+
+		g.It("can be decrypted", func() {
+			var session map[string]interface{}
+			err := e.DecryptAndVerify(cookieContent, &session)
 			g.Assert(err).Eql(nil)
 			g.Assert(session["session_id"]).Eql("b2d63c07ea7a9d58e415e3672e3f31a2")
 		})
@@ -187,6 +280,66 @@ func ExampleMessageEncryptor_DecryptAndVerify() {
 	secret := kg.CacheGenerate(encryptedCookieSalt, 32)
 	signSecret := kg.CacheGenerate(encryptedSignedCookieSalt, 64)
 	e := MessageEncryptor{Key: secret, SignKey: signSecret}
+	sessionString, err := e.EncryptAndSign(john)
+	if err != nil {
+		panic(err)
+	}
+
+	// decrypting the person object contained in the session
+	var sessionContent Person
+	err = e.DecryptAndVerify(sessionString, &sessionContent)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%#v\n", sessionContent)
+
+	//Output:
+	// crypto.Person{Id:12, FirstName:"John", LastName:"Doe", Age:42}
+}
+
+func ExampleMessageEncryptor_EncryptAndSignGCM() {
+	type Person struct {
+		Id        int    `json:"id"`
+		FirstName string `json:"firstName"`
+		LastName  string `json:"lastName"`
+		Age       int    `json:"age"`
+	}
+	john := Person{Id: 12, FirstName: "John", LastName: "Doe", Age: 42}
+
+	k := GenerateRandomKey(32)
+	e := MessageEncryptor{Key: k, Cipher: "aes-256-gcm"}
+
+	// string encoding example
+	msg, err := e.EncryptAndSign("my secret data")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(msg)
+
+	// struct encoding example
+	msg, err = e.EncryptAndSign(john)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(msg)
+}
+
+func ExampleMessageEncryptor_DecryptAndVerifyGCM() {
+
+	type Person struct {
+		Id        int    `json:"id"`
+		FirstName string `json:"firstName"`
+		LastName  string `json:"lastName"`
+		Age       int    `json:"age"`
+	}
+	john := Person{Id: 12, FirstName: "John", LastName: "Doe", Age: 42}
+
+	railsSecret := "f7b5763636f4c1f3ff4bd444eacccca295d87b990cc104124017ad70550edcfd22b8e89465338254e0b608592a9aac29025440bfd9ce53579835ba06a86f85f9"
+	authenticatedCookieSalt := []byte("authenticated encrypted cookie")
+
+	kg := KeyGenerator{Secret: railsSecret}
+	secret := kg.CacheGenerate(authenticatedCookieSalt, 32)
+	e := MessageEncryptor{Key: secret, Cipher: "aes-256-gcm"}
 	sessionString, err := e.EncryptAndSign(john)
 	if err != nil {
 		panic(err)

--- a/crypto/null_msg_serializer_test.go
+++ b/crypto/null_msg_serializer_test.go
@@ -1,8 +1,9 @@
 package crypto
 
 import (
-	. "github.com/franela/goblin"
 	"testing"
+
+	. "github.com/franela/goblin"
 )
 
 func TestNullSerializerSerializer(t *testing.T) {
@@ -28,14 +29,14 @@ func TestNullSerializerSerializer(t *testing.T) {
 
 		g.It("serializes properly", func() {
 			g.Assert(err).Eql(err)
-			g.Assert(output).Eql("map[foo:matt bar:aimonetti]")
+			g.Assert(output).Eql("map[bar:aimonetti foo:matt]")
 		})
 
 		g.It("can be deserialized", func() {
 			var o string
 			err := serializer.Unserialize(output, &o)
 			g.Assert(err).Eql(nil)
-			g.Assert(o).Eql("map[foo:matt bar:aimonetti]")
+			g.Assert(o).Eql("map[bar:aimonetti foo:matt]")
 		})
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/mattetti/goRailsYourself
+
+go 1.15
+
+require (
+	github.com/fiam/gounidecode v0.0.0-20150629112515-8deddbd03fec
+	github.com/franela/goblin v0.0.0-20201006155558-6240afcb2eb7
+	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/fiam/gounidecode v0.0.0-20150629112515-8deddbd03fec h1:XvkU8wCqlvrrxuEw4h11yu9yq8ciB5w2Js+VSwp0WWQ=
+github.com/fiam/gounidecode v0.0.0-20150629112515-8deddbd03fec/go.mod h1:WuPQ88SgkK3OxlJQxlU/PBVn8FOC1JPjXINk7JhOQOA=
+github.com/franela/goblin v0.0.0-20201006155558-6240afcb2eb7 h1:eUae9KtuHjNg5e7DYkn57S/M/ndIICmV1bWs9ejYCx4=
+github.com/franela/goblin v0.0.0-20201006155558-6240afcb2eb7/go.mod h1:VzmDKDJVZI3aJmnRI9VjAn9nJ8qPPsN1fqzr9dqInIo=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
# First commit: 
Adds a go module. I'm making a small assumption based on emperical testing that the associated serialization/testing library are producing alphanumeric ordering now.

# Second commit:
Adds aes-gcm crypto support, updates docs, etc.

# Third & fourth commit:
Adds a Github actions Go CI.